### PR TITLE
artik10 support : Sandbox/pcoval/for/master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # tizen-artik SD Card boot files
+
+For mode details check :
+
+https://wiki.tizen.org/wiki/Tizen_On_ARTIK

--- a/mk_sdboot.sh
+++ b/mk_sdboot.sh
@@ -106,7 +106,7 @@ function find_model {
 	TMPNAME=${TARNAME/artik10/found}
 	if [ $TARNAME != $TMPNAME ]; then
 		MODEL="artik10"
-		PARAMS_OFFSET=1031
+		PARAMS_OFFSET=1231
 	fi
 }
 


### PR DESCRIPTION
Hi,
There is a small error in uboot offset for ARTIK10

I tested on ARTIK10 with :

Linux version 3.10.93-3.8-arm-artik10

e44ded0ae1c73d5cbc4ba8d873d71b23  common-boot-armv7l-artik10/tizen-common_20160606.1_common-boot-armv7l-artik10.tar.gz

1873905b0b46e7bc928ac09213e6a05c  common-wayland-3parts-armv7l-artik/tizen-common_20160606.1_common-wayland-3parts-armv7l-artik.tar.gz
